### PR TITLE
Fixed misspelling

### DIFF
--- a/i18n/en/chronos.ftl
+++ b/i18n/en/chronos.ftl
@@ -10,7 +10,7 @@ timer-duration = Pomodoro duration
 minutes = minutes
 pause-duration = Pause duration
 long-pause-duration = Long pause duration
-pomodoro-before-long-pause = Pomodoro vefore long pause
+pomodoro-before-long-pause = Pomodoro before long pause
 pause = Pause
 history = History
 


### PR DESCRIPTION
vefore -> before